### PR TITLE
mata: remove rounded corner radius dimension

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/dimens.xml
+++ b/overlay/frameworks/base/core/res/res/values/dimens.xml
@@ -23,6 +23,5 @@
     <!-- Height of the status bar in landscape -->
     <dimen name="status_bar_height_landscape">28dp</dimen>
     <dimen name="quick_qs_offset_height">144px</dimen>
-    <dimen name="rounded_corner_radius">16px</dimen>
 
 </resources>


### PR DESCRIPTION
This screws up the assistant handles, so remove it to match stock

Change-Id: I1fc07b2d12ad08e47bd16700747f1ff23b948768